### PR TITLE
chore: pointed FilePicker construction to configured implementation

### DIFF
--- a/module/sheets/actor-npc-sheet.mjs
+++ b/module/sheets/actor-npc-sheet.mjs
@@ -355,7 +355,7 @@ export class HouseholdNPCActorSheet extends HandlebarsApplicationMixin(ActorShee
     const field = target.dataset.field || "img";
     const current = foundry.utils.getProperty(this.document, field);
 
-    const fp = new foundry.applications.apps.FilePicker({
+    const fp = new foundry.applications.apps.FilePicker.implementation({
       type: "image",
       current: current,
       callback: (path) => this.document.update({ [field]: path })

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -409,7 +409,7 @@ export class HouseholdActorSheet extends HandlebarsApplicationMixin(ActorSheetV2
     const field = target.dataset.field || "img";
     const current = foundry.utils.getProperty(this.document, field);
 
-    const fp = new foundry.applications.apps.FilePicker({
+    const fp = new foundry.applications.apps.FilePicker.implementation({
       type: "image",
       current: current,
       callback: (path) => this.document.update({ [field]: path })

--- a/module/sheets/item-sheet.mjs
+++ b/module/sheets/item-sheet.mjs
@@ -212,7 +212,7 @@ export class HouseholdItemSheet extends HandlebarsApplicationMixin(ItemSheetV2) 
     const field = target.dataset.field || "img";
     const current = foundry.utils.getProperty(this.document, field);
 
-    const fp = new foundry.applications.apps.FilePicker({
+    const fp = new foundry.applications.apps.FilePicker.implementation({
       type: "image",
       current: current,
       callback: (path) => this.document.update({ [field]: path })


### PR DESCRIPTION
The system currently pulls the default FilePicker implementation regardless if the underlying implementation has been configured via a module.  This PR instantiates the FilePicker using the Foundry recommended approach, such that modules can enhance FilePicker behavior.